### PR TITLE
Move GH pages pathing to separate config file

### DIFF
--- a/_ghpages_config.yml
+++ b/_ghpages_config.yml
@@ -1,5 +1,6 @@
 title: SimpleReport
-url: https://simplereport.cdc.gov
+baseurl: /SimpleReport_Public_Site
+url: http://cdcgov.github.io
 dap_agency: HHS
 dap_subagency: CDC
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch": "gulp watch",
     "eslint": "eslint assets/js/",
     "build": "gulp build-sass && bundle exec jekyll build --config _config.yml",
-    "deploy": "gh-pages -d _site"
+    "deploy": "gulp build-sass && bundle exec jekyll build --config _ghpages_config.yml && gh-pages -d _site"
   },
   "dependencies": {
     "gulp-watch": "^5.0.0",


### PR DESCRIPTION
Resolves #1 

This moves the `baseurl` configuration setting required for GH Pages to a separate config file, `_ghpages_config.yml`, because it conflicts with the main deployment environment.

I also changed the `npm run deploy` script to use  `_ghpages_config.yml` so that it still deploys to GH Pages correctly.