### PR TITLE
Make a few changes for GH pages deploys

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,18 +11,18 @@ USWDS SASS GULPFILE
 ----------------------------------------
 */
 
-const autoprefixer = require("autoprefixer");
-const csso = require("postcss-csso");
+const autoprefixer = require('autoprefixer');
+const csso = require('postcss-csso');
 const uncss = require('postcss-uncss');
-const gulp = require("gulp");
-const pkg = require("./node_modules/uswds/package.json");
-const postcss = require("gulp-postcss");
-const replace = require("gulp-replace");
-const sass = require("gulp-sass");
-const sourcemaps = require("gulp-sourcemaps");
-const uswds = require("./node_modules/uswds-gulp/config/uswds");
+const gulp = require('gulp');
+const pkg = require('./node_modules/uswds/package.json');
+const postcss = require('gulp-postcss');
+const replace = require('gulp-replace');
+const sass = require('gulp-sass');
+const sourcemaps = require('gulp-sourcemaps');
+const uswds = require('./node_modules/uswds-gulp/config/uswds');
 
-sass.compiler = require("sass");
+sass.compiler = require('sass');
 
 /*
 ----------------------------------------
@@ -36,24 +36,27 @@ PATHS
 */
 
 // Project Sass source directory
-const PROJECT_SASS_SRC = "./_sass";
+const PROJECT_SASS_SRC = './_sass';
 
 // Images destination
-const IMG_DEST = "./assets/uswds/img";
+const IMG_DEST = './assets/uswds/img';
 
 // Fonts destination
-const FONTS_DEST = "./assets/uswds/fonts";
+const FONTS_DEST = './assets/uswds/fonts';
 
 // Javascript destination
-const JS_DEST = "./assets/uswds/js";
+const JS_DEST = './assets/uswds/js';
 
 // Compiled CSS destination
-const CSS_DEST = "./assets/uswds/css";
+const CSS_DEST = './assets/uswds/css';
 
 // Site CSS destination
 // Like the _site/assets/css directory in Jekyll, if necessary.
 // If using, uncomment line 106
-const SITE_CSS_DEST = "./assets/uswds/css";
+const SITE_CSS_DEST = './assets/uswds/css';
+
+// Check if building for GH pages
+const ghPages = process.argv[3] === '--ghpages' ? true : false;
 
 /*
 ----------------------------------------
@@ -61,34 +64,36 @@ TASKS
 ----------------------------------------
 */
 
-gulp.task("copy-uswds-setup", () => {
+gulp.task('copy-uswds-setup', () => {
   return gulp
     .src(`${uswds}/scss/theme/**/**`)
     .pipe(gulp.dest(`${PROJECT_SASS_SRC}`));
 });
 
-gulp.task("copy-uswds-fonts", () => {
+gulp.task('copy-uswds-fonts', () => {
   return gulp.src(`${uswds}/fonts/**/**`).pipe(gulp.dest(`${FONTS_DEST}`));
 });
 
-gulp.task("copy-subset-fonts", () => {
-  return gulp.src(`_subsetfonts/**/**`).pipe(gulp.dest(`${FONTS_DEST}`, {overwrite: true}));
+gulp.task('copy-subset-fonts', () => {
+  return gulp
+    .src(`_subsetfonts/**/**`)
+    .pipe(gulp.dest(`${FONTS_DEST}`, { overwrite: true }));
 });
 
-gulp.task("copy-uswds-images", () => {
+gulp.task('copy-uswds-images', () => {
   return gulp.src(`${uswds}/img/**/**`).pipe(gulp.dest(`${IMG_DEST}`));
 });
 
-gulp.task("copy-uswds-js", () => {
+gulp.task('copy-uswds-js', () => {
   return gulp.src(`${uswds}/js/**/**`).pipe(gulp.dest(`${JS_DEST}`));
 });
 
-gulp.task("build-sass", function() {
+gulp.task('build-sass', function () {
   var plugins = [
     // Autoprefix
     autoprefixer({
       cascade: false,
-      grid: true
+      grid: true,
     }),
     // Minify
     csso({ forceMediaMerge: false }),
@@ -102,13 +107,18 @@ gulp.task("build-sass", function() {
           includePaths: [
             `${PROJECT_SASS_SRC}`,
             `${uswds}/scss`,
-            `${uswds}/scss/packages`
-          ]
+            `${uswds}/scss/packages`,
+          ],
         })
       )
-      .pipe(replace(/\buswds @version\b/g, "based on uswds v" + pkg.version))
+      .pipe(replace(/\buswds @version\b/g, 'based on uswds v' + pkg.version))
+      .pipe(
+        ghPages
+          ? replace(/\/assets\/img/g, '/SimpleReport_Public_Site/assets/img')
+          : null
+      )
       .pipe(postcss(plugins))
-      .pipe(sourcemaps.write("."))
+      .pipe(sourcemaps.write('.'))
       // uncomment the next line if necessary for Jekyll to build properly
       .pipe(gulp.dest(`${SITE_CSS_DEST}`))
       .pipe(gulp.dest(`${CSS_DEST}`))
@@ -116,46 +126,47 @@ gulp.task("build-sass", function() {
 });
 
 gulp.task('uncss', function () {
-    var plugins = [
-        uncss({
-            html: ['./_site/**/*.html'],
-            htmlroot: './_site',
-            ignore: [
-              '.usa-overlay.is-visible',
-              /^\.usa-nav/,
-              /^\.usa-accordion__button/,
-              /^\.usa-banner__button/,
-              /^\.usa-banner__header--expanded/,
-              /^\.usa-alert/,
-              /^\.fba-alert/,
-              /^\.usa-menu-btn/,
-              '.page--home .usa-nav__primary button[aria-expanded=true]',
-              '#fba-touchpoints-page-form-yes',
-              '#fba-touchpoints-page-form-no',
-            ],
-        }),
-    ];
-    return gulp.src(`${SITE_CSS_DEST}/*.css`)
-        .pipe(postcss(plugins))
-        .pipe(gulp.dest(`${SITE_CSS_DEST}`));
+  var plugins = [
+    uncss({
+      html: ['./_site/**/*.html'],
+      htmlroot: './_site',
+      ignore: [
+        '.usa-overlay.is-visible',
+        /^\.usa-nav/,
+        /^\.usa-accordion__button/,
+        /^\.usa-banner__button/,
+        /^\.usa-banner__header--expanded/,
+        /^\.usa-alert/,
+        /^\.fba-alert/,
+        /^\.usa-menu-btn/,
+        '.page--home .usa-nav__primary button[aria-expanded=true]',
+        '#fba-touchpoints-page-form-yes',
+        '#fba-touchpoints-page-form-no',
+      ],
+    }),
+  ];
+  return gulp
+    .src(`${SITE_CSS_DEST}/*.css`)
+    .pipe(postcss(plugins))
+    .pipe(gulp.dest(`${SITE_CSS_DEST}`));
 });
 
 gulp.task(
-  "init",
+  'init',
   gulp.series(
-    "copy-uswds-setup",
-    "copy-uswds-fonts",
-    "copy-subset-fonts",
-    "copy-uswds-images",
-    "copy-uswds-js",
-    "build-sass"
+    'copy-uswds-setup',
+    'copy-uswds-fonts',
+    'copy-subset-fonts',
+    'copy-uswds-images',
+    'copy-uswds-js',
+    'build-sass'
   )
 );
 
-gulp.task("watch-sass", function() {
-  gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series("build-sass"));
+gulp.task('watch-sass', function () {
+  gulp.watch(`${PROJECT_SASS_SRC}/**/*.scss`, gulp.series('build-sass'));
 });
 
-gulp.task("watch", gulp.series("build-sass", "watch-sass"));
+gulp.task('watch', gulp.series('build-sass', 'watch-sass'));
 
-gulp.task("default", gulp.series("watch"));
+gulp.task('default', gulp.series('watch'));

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch": "gulp watch",
     "eslint": "eslint assets/js/",
     "build": "gulp build-sass && bundle exec jekyll build --config _config.yml",
-    "deploy": "gulp build-sass && bundle exec jekyll build --config _ghpages_config.yml && gh-pages -d _site",
+    "deploy": "gulp build-sass --ghpages && bundle exec jekyll build --config _ghpages_config.yml && gh-pages -d _site",
     "deploy-azure-beta": "./deploy.sh beta",
     "deploy-azure-demo": "./deploy.sh demo"
   },


### PR DESCRIPTION
Added an option for the `build-sass` task to the gulpfile so that we can prepend the `/SimpleReport_Public_Site` to any image paths in the CSS for GH pages builds